### PR TITLE
Fix compilation in release mode with the default config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@
 //! languages used in offline rendering this crate should feel like
 //! home.
 use core::ops::{Add, Mul};
-#[cfg(debug_assertions)]
 #[cfg(feature = "monotonic_check")]
 use is_sorted::IsSorted;
 use lerp::Lerp;


### PR DESCRIPTION
There was an extra `#[cfg(debug_assertions)]` that made the compilation fail with `--release` with the default feature flags (`monotonic_check`)