### PR TITLE
Fix inverted knot count check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ where
             4 + B::EXTRA_KNOTS,
             knots.len()
         );
-    } else if (B::EXTRA_KNOTS != 0) && ((knots.len() - B::EXTRA_KNOTS) % 4 == 0)
+    } else if (B::EXTRA_KNOTS != 0) && ((knots.len() - B::EXTRA_KNOTS) % 4 != 0)
     {
         panic!(
             "{} curve must have 4×𝘯+{} knots. Found: {}.",


### PR DESCRIPTION
Pretty sure this check was backwards
Without this fix calling eg `spline<Bezier, ...>` with 7 knots panics with `Bezier curve must have 4×𝘯+3 knots. Found: 7.` in debug